### PR TITLE
relax dependencies

### DIFF
--- a/lib/pubchem/version.rb
+++ b/lib/pubchem/version.rb
@@ -1,3 +1,3 @@
 module Pubchem
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/pubchem.gemspec
+++ b/pubchem.gemspec
@@ -21,11 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "mechanize", "~> 2.7.3"
-  spec.add_runtime_dependency "nokogiri", "~> 1.6.6.2"
-  spec.add_runtime_dependency "fuzzy-string-match", "~> 0.9.7"
-  spec.add_runtime_dependency "ox", "~> 2.2.1"
-
-  spec.add_development_dependency "bundler", "~> 1.10"
-
+  spec.add_runtime_dependency "mechanize", "> 2.7.3"
+  spec.add_runtime_dependency "nokogiri", "~> 1.16" # Nokogiri should always be the latest
+  spec.add_runtime_dependency "fuzzy-string-match", "> 0.9.7" # 1.0 came out in 2017
+  spec.add_runtime_dependency "ox", "> 2.2.1" # 2.14.x is latest
 end


### PR DESCRIPTION
Hi,

I wanted to give your gem a try, but simple `gem install pubchem` failed. 

`ox` gem is locked to an ancient 2.2.x version
which includes a C extension that does not compile on my "recent" 4yr old mac.

```
current directory: /Users/majobin/.asdf/installs/ruby/3.0.6/lib/ruby/gems/3.0.0/gems/ox-2.2.4/ext/ox
make DESTDIR\= sitearchdir\=./.gem.20240520-12147-j5e5lq sitelibdir\=./.gem.20240520-12147-j5e5lq
compiling base64.c
compiling cache.c
cache.c:30:25: warning: implicit conversion from 'int' to 'char' changes value from 255 to -1 [-Wconstant-conversion]
    *d = (255 <= len) ? 255 : len;
       ~                ^~~
1 warning generated.
compiling cache8.c
compiling cache8_test.c
compiling cache_test.c
compiling dump.c
dump.c:604:27: error: incompatible function pointer types passing 'int (VALUE, VALUE, Out)' (aka 'int (unsigned long, unsigned long, struct _Out *)') to parameter of type 'int (*)(VALUE, VALUE, VALUE)' (aka 'int (*)(unsigned long, unsigned long, unsigned long)') [-Wincompatible-function-pointer-types]
            rb_hash_foreach(obj, dump_hash, (VALUE)out);
                                 ^~~~~~~~~
```

This triggered me to relax your dependencies and bump the version of this gem.